### PR TITLE
export TF saved-models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ vasudevgupta/
 wav2vec2-base-960h/
 wandb
 tf-wav2vec2-base-960h/
+saved-model/
 
 debugger.ipynb

--- a/notebooks/wav2vec2-base-saved-model.ipynb
+++ b/notebooks/wav2vec2-base-saved-model.ipynb
@@ -26,102 +26,78 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import tensorflow as tf"
+    "!git clone https://github.com/vasudevgupta7/gsoc-wav2vec2 --branch=export\n",
+    "\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "os.chdir(\"gsoc-wav2vec2\")\n",
+    "sys.path.append(\"src\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "import tensorflow_hub as hub\n",
+    "\n",
+    "from wav2vec2 import Wav2Vec2Config, CTCLoss\n",
+    "\n",
+    "config = Wav2Vec2Config()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Available signatures are: ['infer', 'train']\n"
+     ]
+    }
+   ],
    "source": [
     "# TODO: update it to load from TFHub later\n",
-    "loaded = tf.saved_model.load(\"../src/saved-model\")"
+    "loaded = hub.load(\"saved-model\")\n",
+    "print(\"Available signatures are:\", list(loaded.signatures.keys()))\n",
+    "pretrained_model = loaded.signatures[\"train\"]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "['infer', 'train']"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 3
-    }
-   ],
-   "source": [
-    "list(loaded.signatures.keys())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = loaded.signatures[\"train\"]\n",
-    "\n",
-    "@tf.function(jit_compile=True)\n",
-    "def forward(batch):\n",
-    "    return model(batch)"
+    "pretrained_model = hub.KerasLayer(pretrained_model, trainable=False)\n",
+    "lm_head = tf.keras.layers.Dense(config.vocab_size)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "{'output_0': <tf.Tensor: shape=(2, 768, 768), dtype=float32, numpy=\n",
-       " array([[[ 0.04981414, -0.11246528,  0.22671068, ...,  0.4736007 ,\n",
-       "           0.0594595 , -0.16712372],\n",
-       "         [-0.05188152, -0.14415626,  0.21715117, ...,  0.4496262 ,\n",
-       "           0.19341631, -0.128913  ],\n",
-       "         [ 0.21963328, -0.04843174,  0.10294376, ...,  0.36572003,\n",
-       "           0.15869941,  0.03712311],\n",
-       "         ...,\n",
-       "         [ 0.033603  , -0.12690043,  0.10068704, ...,  0.47456473,\n",
-       "           0.06561999, -0.08360367],\n",
-       "         [ 0.14492346, -0.14835656,  0.09673587, ...,  0.53533024,\n",
-       "           0.25344235, -0.00547679],\n",
-       "         [ 0.04792857, -0.21567795,  0.177122  , ...,  0.3946013 ,\n",
-       "           0.12262318, -0.16006427]],\n",
-       " \n",
-       "        [[ 0.08920608, -0.00930583,  0.224908  , ...,  0.2948055 ,\n",
-       "           0.02860889, -0.05696075],\n",
-       "         [-0.031082  , -0.05461206,  0.19720137, ...,  0.28247502,\n",
-       "           0.0928454 , -0.06703105],\n",
-       "         [ 0.22385038, -0.17530268,  0.2455038 , ...,  0.3629407 ,\n",
-       "           0.22896694, -0.00575246],\n",
-       "         ...,\n",
-       "         [ 0.11078387, -0.14083627,  0.28719676, ...,  0.58891124,\n",
-       "           0.23505788, -0.1006375 ],\n",
-       "         [-0.06454392, -0.11049275,  0.08029447, ...,  0.43157318,\n",
-       "           0.07856634, -0.07067369],\n",
-       "         [ 0.17163242, -0.10659251,  0.34340432, ...,  0.14162482,\n",
-       "           0.2449391 , -0.02186076]]], dtype=float32)>}"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 5
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Number of trainable variables: 2\n"
+     ]
     }
    ],
    "source": [
-    "batch = tf.random.uniform(shape=(2, 246000))\n",
-    "forward(batch)"
+    "print(\"Number of trainable variables:\", len(pretrained_model.trainable_variables) + len(lm_head.trainable_variables))"
    ]
   },
   {
@@ -130,8 +106,82 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO: add how to train?"
+    "BATCH_SIZE_PER_DEVICE = 8\n",
+    "BATCH_SIZE = BATCH_SIZE_PER_DEVICE\n",
+    "LEARNING_RATE = 5e-5"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss_fn = CTCLoss(config, (BATCH_SIZE_PER_DEVICE, 246000), division_factor=BATCH_SIZE)\n",
+    "optimizer = tf.keras.optimizers.Adam(LEARNING_RATE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@tf.function(jit_compile=True)\n",
+    "def forward(batch):\n",
+    "    return lm_head(pretrained_model(batch)[\"output_0\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@tf.function\n",
+    "def train_step(speech, labels):\n",
+    "    with tf.GradientTape() as gtape:\n",
+    "        speech = forward(speech)\n",
+    "        loss = loss_fn(labels, speech)\n",
+    "    trainable_variables = list(pretrained_model.trainable_variables) + lm_head.trainable_variables\n",
+    "    grads = gtape.gradient(loss, trainable_variables)\n",
+    "    optimizer.apply_gradients(zip(grads, trainable_variables))\n",
+    "    return loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from data_utils import LibriSpeechDataLoaderArgs, LibriSpeechDataLoader\n",
+    "\n",
+    "data_args = LibriSpeechDataLoaderArgs(from_tfrecords=False, data_dir=\"data/LibriSpeech/test-clean\")\n",
+    "dataloader = LibriSpeechDataLoader(data_args)\n",
+    "dataset = dataloader(seed=None)\n",
+    "\n",
+    "dataset = dataset.take(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tqdm import tqdm\n",
+    "\n",
+    "for speech, label in tqdm(dataset):\n",
+    "    train_step(speech, label)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ]
 }

--- a/notebooks/wav2vec2-base-saved-model.ipynb
+++ b/notebooks/wav2vec2-base-saved-model.ipynb
@@ -1,187 +1,515 @@
 {
- "metadata": {
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.10"
+    },
+    "orig_nbformat": 4,
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3.8.10 64-bit ('t5': conda)"
+    },
+    "interpreter": {
+      "hash": "184c0bf4d405d4a36e719b504ff2a22c838d19108535bf816dff1a5aad495b87"
+    },
+    "colab": {
+      "name": "wav2vec2-base-saved-model.ipynb",
+      "provenance": [],
+      "include_colab_link": true
+    },
+    "accelerator": "GPU"
   },
-  "orig_nbformat": 4,
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.8.10 64-bit ('t5': conda)"
-  },
-  "interpreter": {
-   "hash": "184c0bf4d405d4a36e719b504ff2a22c838d19108535bf816dff1a5aad495b87"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2,
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!git clone https://github.com/vasudevgupta7/gsoc-wav2vec2 --branch=export\n",
-    "\n",
-    "import sys\n",
-    "import os\n",
-    "\n",
-    "os.chdir(\"gsoc-wav2vec2\")\n",
-    "sys.path.append(\"src\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import tensorflow as tf\n",
-    "import tensorflow_hub as hub\n",
-    "\n",
-    "from wav2vec2 import Wav2Vec2Config, CTCLoss\n",
-    "\n",
-    "config = Wav2Vec2Config()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Available signatures are: ['infer', 'train']\n"
-     ]
-    }
-   ],
-   "source": [
-    "# TODO: update it to load from TFHub later\n",
-    "loaded = hub.load(\"saved-model\")\n",
-    "print(\"Available signatures are:\", list(loaded.signatures.keys()))\n",
-    "pretrained_model = loaded.signatures[\"train\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pretrained_model = hub.KerasLayer(pretrained_model, trainable=False)\n",
-    "lm_head = tf.keras.layers.Dense(config.vocab_size)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/vasudevgupta7/gsoc-wav2vec2/blob/export/notebooks/wav2vec2-base-saved-model.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
     {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Number of trainable variables: 2\n"
-     ]
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ndG8MjmJeicp"
+      },
+      "source": [
+        "# How to train TensorFlow saved-model with extra head\n",
+        "\n",
+        "In this notebook, we will load pre-trained wav2vec2 model from TFHub and will train it on librispeech dataset by appending one extra head over the top of our pre-trained model."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "rWk8nL6Ui-_0"
+      },
+      "source": [
+        "## Setting Up\n",
+        "\n",
+        "Before diving into it, let's see what GPU we got using `nvidia-smi`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Y2DQV2hde_Vh",
+        "outputId": "2a490fc5-cf37-4dbd-da00-7fbb2c6306c8",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "!nvidia-smi"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Sat Jul 17 12:41:30 2021       \n",
+            "+-----------------------------------------------------------------------------+\n",
+            "| NVIDIA-SMI 470.42.01    Driver Version: 460.32.03    CUDA Version: 11.2     |\n",
+            "|-------------------------------+----------------------+----------------------+\n",
+            "| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |\n",
+            "| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |\n",
+            "|                               |                      |               MIG M. |\n",
+            "|===============================+======================+======================|\n",
+            "|   0  Tesla T4            Off  | 00000000:00:04.0 Off |                    0 |\n",
+            "| N/A   53C    P0    28W /  70W |      0MiB / 15109MiB |      0%      Default |\n",
+            "|                               |                      |                  N/A |\n",
+            "+-------------------------------+----------------------+----------------------+\n",
+            "                                                                               \n",
+            "+-----------------------------------------------------------------------------+\n",
+            "| Processes:                                                                  |\n",
+            "|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |\n",
+            "|        ID   ID                                                   Usage      |\n",
+            "|=============================================================================|\n",
+            "|  No running processes found                                                 |\n",
+            "+-----------------------------------------------------------------------------+\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8hBGUWT_mKkw"
+      },
+      "source": [
+        "Following cell will clone the code repositary and will install all the dependencies."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "seqTlMyeZvM4",
+        "outputId": "e1b14e4a-9273-4929-9480-070e730680cb",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "!git clone https://github.com/vasudevgupta7/gsoc-wav2vec2 --branch=export\n",
+        "\n",
+        "import sys\n",
+        "import os\n",
+        "\n",
+        "os.chdir(\"gsoc-wav2vec2\")\n",
+        "sys.path.append(\"src\")\n",
+        "\n",
+        "!pip3 install -qe ."
+      ],
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "fatal: destination path 'gsoc-wav2vec2' already exists and is not an empty directory.\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "bFQDM1t8Z_XK",
+        "outputId": "718d809f-d095-4586-8383-bda1beee0e30",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "# This cell will be removed after model get exported to TFHub\n",
+        "!wget https://huggingface.co/vasudevgupta/tf-wav2vec2-base/resolve/main/wav2vec2-base.tar.gz\n",
+        "!tar -xf wav2vec2-base.tar.gz"
+      ],
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "--2021-07-17 12:41:35--  https://huggingface.co/vasudevgupta/tf-wav2vec2-base/resolve/main/wav2vec2-base.tar.gz\n",
+            "Resolving huggingface.co (huggingface.co)... 15.197.130.34\n",
+            "Connecting to huggingface.co (huggingface.co)|15.197.130.34|:443... connected.\n",
+            "HTTP request sent, awaiting response... 302 Found\n",
+            "Location: https://cdn-lfs.huggingface.co/vasudevgupta/tf-wav2vec2-base/ba29ac5ff1f78271a6c9e6466cedd221e811b5ed58020337d238bc14512de9f3 [following]\n",
+            "--2021-07-17 12:41:35--  https://cdn-lfs.huggingface.co/vasudevgupta/tf-wav2vec2-base/ba29ac5ff1f78271a6c9e6466cedd221e811b5ed58020337d238bc14512de9f3\n",
+            "Resolving cdn-lfs.huggingface.co (cdn-lfs.huggingface.co)... 52.85.144.69, 52.85.144.70, 52.85.144.56, ...\n",
+            "Connecting to cdn-lfs.huggingface.co (cdn-lfs.huggingface.co)|52.85.144.69|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 387426816 (369M) [application/octet-stream]\n",
+            "Saving to: ‘wav2vec2-base.tar.gz.1’\n",
+            "\n",
+            "wav2vec2-base.tar.g 100%[===================>] 369.48M  37.5MB/s    in 9.3s    \n",
+            "\n",
+            "2021-07-17 12:41:44 (39.9 MB/s) - ‘wav2vec2-base.tar.gz.1’ saved [387426816/387426816]\n",
+            "\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "M3_fgx4eZvM7",
+        "outputId": "40fa6386-a2fc-478e-a42c-b2275ac8ce22",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "import tensorflow as tf\n",
+        "import tensorflow_hub as hub\n",
+        "\n",
+        "from wav2vec2 import Wav2Vec2Config, CTCLoss\n",
+        "\n",
+        "config = Wav2Vec2Config()"
+      ],
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/requests/__init__.py:91: RequestsDependencyWarning: urllib3 (1.26.6) or chardet (3.0.4) doesn't match a supported version!\n",
+            "  RequestsDependencyWarning)\n"
+          ],
+          "name": "stderr"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "B_5cjb_EZvM8",
+        "outputId": "499f46e3-3feb-4ead-c0de-5fa6f637e5f9",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "# TODO: update it to load from TFHub later\n",
+        "loaded = hub.load(\"saved-model\")\n",
+        "print(\"Available signatures are:\", list(loaded.signatures.keys()))"
+      ],
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Available signatures are: ['infer', 'train']\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "NO6QRC7KZvM9"
+      },
+      "source": [
+        "pretrained_model = loaded.signatures[\"train\"]\n",
+        "pretrained_model = hub.KerasLayer(pretrained_model, trainable=False)\n",
+        "\n",
+        "lm_head = tf.keras.layers.Dense(config.vocab_size)"
+      ],
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "3f5M8YXXZvM_"
+      },
+      "source": [
+        "@tf.function(jit_compile=True)\n",
+        "def forward(batch):\n",
+        "    return lm_head(pretrained_model(batch)[\"output_0\"])"
+      ],
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "F_OWtO4uZvM-"
+      },
+      "source": [
+        "BATCH_SIZE = 2\n",
+        "LEARNING_RATE = 5e-5\n",
+        "AUDIO_MAXLEN = 246000"
+      ],
+      "execution_count": 9,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ZgL5wyaXZvM-",
+        "outputId": "5b6b37bc-836d-4dbb-b94d-70cd4a58a033",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "forward(tf.random.uniform(shape=(BATCH_SIZE, AUDIO_MAXLEN)))\n",
+        "print(\"Number of trainable variables:\", len(list(pretrained_model.trainable_variables) + lm_head.trainable_variables))"
+      ],
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Number of trainable variables: 2\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "glDepVEHZvM_"
+      },
+      "source": [
+        "loss_fn = CTCLoss(config, (BATCH_SIZE, AUDIO_MAXLEN), division_factor=BATCH_SIZE)\n",
+        "optimizer = tf.keras.optimizers.Adam(LEARNING_RATE)"
+      ],
+      "execution_count": 11,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "I4kIEC77cBCM",
+        "outputId": "f5a2a8a2-a0a0-41df-b4a4-4df480c3c297",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "!wget https://huggingface.co/datasets/vasudevgupta/gsoc-librispeech/resolve/main/train-clean-100/train-clean-100-0.tfrecord -P /content/gsoc-wav2vec2/data/train/"
+      ],
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "--2021-07-17 12:42:20--  https://huggingface.co/datasets/vasudevgupta/gsoc-librispeech/resolve/main/train-clean-100/train-clean-100-0.tfrecord\n",
+            "Resolving huggingface.co (huggingface.co)... 15.197.130.34\n",
+            "Connecting to huggingface.co (huggingface.co)|15.197.130.34|:443... connected.\n",
+            "HTTP request sent, awaiting response... 302 Found\n",
+            "Location: https://cdn-lfs.huggingface.co/datasets/vasudevgupta/gsoc-librispeech/df6dfb983f6514a98fc05d2ee219f57b1286589d61c1271bb10a0ed3effd6ae8 [following]\n",
+            "--2021-07-17 12:42:20--  https://cdn-lfs.huggingface.co/datasets/vasudevgupta/gsoc-librispeech/df6dfb983f6514a98fc05d2ee219f57b1286589d61c1271bb10a0ed3effd6ae8\n",
+            "Resolving cdn-lfs.huggingface.co (cdn-lfs.huggingface.co)... 52.85.132.4, 52.85.132.34, 52.85.132.50, ...\n",
+            "Connecting to cdn-lfs.huggingface.co (cdn-lfs.huggingface.co)|52.85.132.4|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 483730930 (461M) [application/octet-stream]\n",
+            "Saving to: ‘/content/gsoc-wav2vec2/data/train/train-clean-100-0.tfrecord.1’\n",
+            "\n",
+            "train-clean-100-0.t 100%[===================>] 461.32M  44.8MB/s    in 8.0s    \n",
+            "\n",
+            "2021-07-17 12:42:28 (57.5 MB/s) - ‘/content/gsoc-wav2vec2/data/train/train-clean-100-0.tfrecord.1’ saved [483730930/483730930]\n",
+            "\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "qbBpo74BcUuI",
+        "outputId": "69d4c6f1-3746-4d48-d923-223d76eaaa33",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "ls /content/gsoc-wav2vec2/data/train/"
+      ],
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "train-clean-100-0.tfrecord  train-clean-100-0.tfrecord.1\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "3m1Bryfocmm2",
+        "outputId": "2e1068b2-f710-4978-ab12-a2d45a0937e4",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "ls"
+      ],
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "\u001b[0m\u001b[01;34massets\u001b[0m/      \u001b[01;34mnotebooks\u001b[0m/        \u001b[01;34msaved-model\u001b[0m/  \u001b[01;34msrc\u001b[0m/        wav2vec2-base.tar.gz\n",
+            "\u001b[01;34mdata\u001b[0m/        readme.md         setup.cfg     \u001b[01;34mtests\u001b[0m/      wav2vec2-base.tar.gz.1\n",
+            "LICENSE.txt  requirements.txt  setup.py      vocab.json\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "jkIu_Wt4ZvNA",
+        "outputId": "878878d1-534a-4133-9381-12ab40887a80",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "from data_utils import LibriSpeechDataLoaderArgs, LibriSpeechDataLoader\n",
+        "\n",
+        "data_args = LibriSpeechDataLoaderArgs(\n",
+        "    from_tfrecords=True,\n",
+        "    tfrecords=[\"data/train/train-clean-100-0.tfrecord\"],\n",
+        "    audio_maxlen=AUDIO_MAXLEN,\n",
+        "    batch_size=BATCH_SIZE,\n",
+        ")\n",
+        "dataloader = LibriSpeechDataLoader(data_args)\n",
+        "dataset = dataloader(seed=None)\n",
+        "\n",
+        "num_batches = 2\n",
+        "dataset = dataset.take(num_batches)"
+      ],
+      "execution_count": 16,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Downloading `vocab.json` from https://github.com/vasudevgupta7/gsoc-wav2vec2/raw/main/data/vocab.json ... DONE\n",
+            "Reading tfrecords from ['data/train/train-clean-100-0.tfrecord'] ... Done!\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "2RYI8ra_ZvNA"
+      },
+      "source": [
+        "@tf.function\n",
+        "def train_step(speech, labels):\n",
+        "    with tf.GradientTape() as gtape:\n",
+        "        speech = forward(speech)\n",
+        "        loss = loss_fn(labels, speech)\n",
+        "    trainable_variables = list(pretrained_model.trainable_variables) + lm_head.trainable_variables\n",
+        "    grads = gtape.gradient(loss, trainable_variables)\n",
+        "    optimizer.apply_gradients(zip(grads, trainable_variables))\n",
+        "    return loss"
+      ],
+      "execution_count": 12,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "zUujvZn4ZvNA"
+      },
+      "source": [
+        "from tqdm import tqdm\n",
+        "\n",
+        "pbar = tqdm(dataset, total=num_batches)\n",
+        "for speech, label in pbar:\n",
+        "    loss = train_step(speech, label)\n",
+        "    pbar.set_postfix(tr_loss=loss)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ssWXWc7CZvNB"
+      },
+      "source": [
+        "@tf.function\n",
+        "def eval_step(speech, labels):\n",
+        "    speech = forward(speech)\n",
+        "    loss = loss_fn(labels, speech)\n",
+        "    return loss"
+      ],
+      "execution_count": 20,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "EQTFVjZghckJ"
+      },
+      "source": [
+        "pbar = tqdm(dataset, total=num_batches)\n",
+        "for speech, label in pbar:\n",
+        "    loss = eval_step(speech, label)\n",
+        "    pbar.set_postfix(val_loss=loss)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vCxfNFFVh9LR"
+      },
+      "source": [
+        ""
+      ],
+      "execution_count": null,
+      "outputs": []
     }
-   ],
-   "source": [
-    "print(\"Number of trainable variables:\", len(pretrained_model.trainable_variables) + len(lm_head.trainable_variables))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "BATCH_SIZE_PER_DEVICE = 8\n",
-    "BATCH_SIZE = BATCH_SIZE_PER_DEVICE\n",
-    "LEARNING_RATE = 5e-5"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "loss_fn = CTCLoss(config, (BATCH_SIZE_PER_DEVICE, 246000), division_factor=BATCH_SIZE)\n",
-    "optimizer = tf.keras.optimizers.Adam(LEARNING_RATE)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "@tf.function(jit_compile=True)\n",
-    "def forward(batch):\n",
-    "    return lm_head(pretrained_model(batch)[\"output_0\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "@tf.function\n",
-    "def train_step(speech, labels):\n",
-    "    with tf.GradientTape() as gtape:\n",
-    "        speech = forward(speech)\n",
-    "        loss = loss_fn(labels, speech)\n",
-    "    trainable_variables = list(pretrained_model.trainable_variables) + lm_head.trainable_variables\n",
-    "    grads = gtape.gradient(loss, trainable_variables)\n",
-    "    optimizer.apply_gradients(zip(grads, trainable_variables))\n",
-    "    return loss"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from data_utils import LibriSpeechDataLoaderArgs, LibriSpeechDataLoader\n",
-    "\n",
-    "data_args = LibriSpeechDataLoaderArgs(from_tfrecords=False, data_dir=\"data/LibriSpeech/test-clean\")\n",
-    "dataloader = LibriSpeechDataLoader(data_args)\n",
-    "dataset = dataloader(seed=None)\n",
-    "\n",
-    "dataset = dataset.take(2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from tqdm import tqdm\n",
-    "\n",
-    "for speech, label in tqdm(dataset):\n",
-    "    train_step(speech, label)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ]
+  ]
 }

--- a/notebooks/wav2vec2-base-saved-model.ipynb
+++ b/notebooks/wav2vec2-base-saved-model.ipynb
@@ -1,0 +1,137 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  },
+  "orig_nbformat": 4,
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3.8.10 64-bit ('t5': conda)"
+  },
+  "interpreter": {
+   "hash": "184c0bf4d405d4a36e719b504ff2a22c838d19108535bf816dff1a5aad495b87"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: update it to load from TFHub later\n",
+    "loaded = tf.saved_model.load(\"../src/saved-model\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "['infer', 'train']"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 3
+    }
+   ],
+   "source": [
+    "list(loaded.signatures.keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = loaded.signatures[\"train\"]\n",
+    "\n",
+    "@tf.function(jit_compile=True)\n",
+    "def forward(batch):\n",
+    "    return model(batch)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "{'output_0': <tf.Tensor: shape=(2, 768, 768), dtype=float32, numpy=\n",
+       " array([[[ 0.04981414, -0.11246528,  0.22671068, ...,  0.4736007 ,\n",
+       "           0.0594595 , -0.16712372],\n",
+       "         [-0.05188152, -0.14415626,  0.21715117, ...,  0.4496262 ,\n",
+       "           0.19341631, -0.128913  ],\n",
+       "         [ 0.21963328, -0.04843174,  0.10294376, ...,  0.36572003,\n",
+       "           0.15869941,  0.03712311],\n",
+       "         ...,\n",
+       "         [ 0.033603  , -0.12690043,  0.10068704, ...,  0.47456473,\n",
+       "           0.06561999, -0.08360367],\n",
+       "         [ 0.14492346, -0.14835656,  0.09673587, ...,  0.53533024,\n",
+       "           0.25344235, -0.00547679],\n",
+       "         [ 0.04792857, -0.21567795,  0.177122  , ...,  0.3946013 ,\n",
+       "           0.12262318, -0.16006427]],\n",
+       " \n",
+       "        [[ 0.08920608, -0.00930583,  0.224908  , ...,  0.2948055 ,\n",
+       "           0.02860889, -0.05696075],\n",
+       "         [-0.031082  , -0.05461206,  0.19720137, ...,  0.28247502,\n",
+       "           0.0928454 , -0.06703105],\n",
+       "         [ 0.22385038, -0.17530268,  0.2455038 , ...,  0.3629407 ,\n",
+       "           0.22896694, -0.00575246],\n",
+       "         ...,\n",
+       "         [ 0.11078387, -0.14083627,  0.28719676, ...,  0.58891124,\n",
+       "           0.23505788, -0.1006375 ],\n",
+       "         [-0.06454392, -0.11049275,  0.08029447, ...,  0.43157318,\n",
+       "           0.07856634, -0.07067369],\n",
+       "         [ 0.17163242, -0.10659251,  0.34340432, ...,  0.14162482,\n",
+       "           0.2449391 , -0.02186076]]], dtype=float32)>}"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 5
+    }
+   ],
+   "source": [
+    "batch = tf.random.uniform(shape=(2, 246000))\n",
+    "forward(batch)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: add how to train?"
+   ]
+  }
+ ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ huggingface-hub
 soundfile
 jiwer
 typeguard
+tensorflow_hub

--- a/src/export2hub.py
+++ b/src/export2hub.py
@@ -1,0 +1,37 @@
+import tensorflow as tf
+
+from convert_torch_to_tf import get_tf_pretrained_model
+from wav2vec2 import Wav2Vec2Config
+
+import argparse
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hf_model_id", default="facebook/wav2vec2-base", type=str)
+    parser.add_argument("--with_lm_head", default=False, type=bool)
+    parser.add_argument("--verbose", default=False, type=bool)
+    parser.add_argument("--saved_model_dir", default="saved-model/", type=str)
+    parser.add_argument("--seqlen", default=246000, type=int)
+    return parser
+
+
+if __name__ == '__main__':
+
+    args = get_parser().parse_args()
+
+    # spec_augmentation can't be supported with saved_model for now
+    config = Wav2Vec2Config(apply_spec_augment=False)
+    model, _ = get_tf_pretrained_model(config, args.hf_model_id, verbose=args.verbose, with_lm_head=args.with_lm_head)
+
+    input_signature = [tf.TensorSpec((None, args.seqlen), dtype=tf.float32)]
+
+    @tf.function(input_signature=input_signature)
+    def infer_function(batch):
+        return model(batch, training=False)
+
+    @tf.function(input_signature=input_signature)
+    def train_function(batch):
+        return model(batch, training=True)
+
+    signatures = {"infer": infer_function, "train": train_function}
+    tf.saved_model.save(model, args.saved_model_dir, signatures=signatures)

--- a/src/wav2vec2/modeling.py
+++ b/src/wav2vec2/modeling.py
@@ -94,7 +94,7 @@ class TFKerasModel(tf.keras.Model):
 
 
 class Wav2Vec2Model(TFKerasModel):
-    def __init__(self, config: Wav2Vec2Config, input_shape=(1, 2048), name="wav2vec2"):
+    def __init__(self, config: Wav2Vec2Config, input_shape=(1, 50000), name="wav2vec2"):
         super().__init__(name=name)
         if not isinstance(config, Wav2Vec2Config):
             raise ValueError("`config` must be an instace of `Wave2Vec2Config`")
@@ -190,7 +190,7 @@ class Wav2Vec2ForCTC(TFKerasModel):
     """Wave2Vec2 model with a CTC head."""
 
     def __init__(
-        self, config: Wav2Vec2Config, input_shape=(1, 2048), name="wav2vec2-ctc"
+        self, config: Wav2Vec2Config, input_shape=(1, 50000), name="wav2vec2-ctc"
     ):
         super().__init__(name=name)
         if not isinstance(config, Wav2Vec2Config):

--- a/tests/test_wav2vec2.py
+++ b/tests/test_wav2vec2.py
@@ -141,7 +141,7 @@ class Wav2Vec2Tester(unittest.TestCase):
         for hf_model_id in HF_MODEL_IDS:
             config = Wav2Vec2Config()
             tf_model, hf_model = get_tf_pretrained_model(
-                config, hf_model_id, verbose=False
+                config, hf_model_id, verbose=False, with_lm_head=True,
             )
             batch, hf_batch, _, _ = self._get_batches()
             tf_logits = tf_model(batch).numpy()


### PR DESCRIPTION
This PR add code for exporting TF saved-model to TF-Hub. Added one [notebook](https://colab.research.google.com/github/vasudevgupta7/gsoc-wav2vec2/blob/export/notebooks/wav2vec2-base-saved-model.ipynb) also to show how extra head can be appended over the pre-trained model and how the resulting model can be trained. I will add some detailed- text in the notebook if basic structure looks fine to you.

I can merge it if everything looks alright to you @sayakpaul @MorganR 