### PR TITLE
Improve data loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ wandb
 tf-wav2vec2-base-960h/
 saved-model/
 
+vocab.json
 debugger.ipynb

--- a/src/convert_torch_to_tf.py
+++ b/src/convert_torch_to_tf.py
@@ -45,7 +45,10 @@ def replace(k: str, prefix) -> str:
 
 
 def get_tf_pretrained_model(
-    config: Wav2Vec2Config, hf_model_id: str, verbose=False, with_lm_head=True,
+    config: Wav2Vec2Config,
+    hf_model_id: str,
+    verbose=False,
+    with_lm_head=True,
 ) -> Union[Wav2Vec2ForCTC, Wav2Vec2Model]:
     """
     Converts HuggingFace PyTorch weights to TensorFlow compatible weights.
@@ -124,8 +127,17 @@ def get_tf_pretrained_model(
 
 def get_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--hf_model_id", type=str, default="facebook/wav2vec2-base", help="Model ID of HuggingFace wav2vec2 which needs to be converted into TensorFlow")
-    parser.add_argument("--with_lm_head", action="store_true", help="Whether to use `Wav2Vec2Model` or `Wav2Vec2ForCTC` from `wav2vec2/modeling.py`")
+    parser.add_argument(
+        "--hf_model_id",
+        type=str,
+        default="facebook/wav2vec2-base",
+        help="Model ID of HuggingFace wav2vec2 which needs to be converted into TensorFlow",
+    )
+    parser.add_argument(
+        "--with_lm_head",
+        action="store_true",
+        help="Whether to use `Wav2Vec2Model` or `Wav2Vec2ForCTC` from `wav2vec2/modeling.py`",
+    )
     return parser
 
 
@@ -134,7 +146,9 @@ if __name__ == "__main__":
     args = get_parser().parse_args()
 
     config = Wav2Vec2Config()
-    tf_model, _ = get_tf_pretrained_model(config, args.hf_model_id, verbose=True, with_lm_head=args.with_lm_head)
+    tf_model, _ = get_tf_pretrained_model(
+        config, args.hf_model_id, verbose=True, with_lm_head=args.with_lm_head
+    )
 
     model_id = "tf-" + args.hf_model_id.split("/")[-1]
     tf_model.save_pretrained(model_id)

--- a/src/export2hub.py
+++ b/src/export2hub.py
@@ -5,23 +5,50 @@ from wav2vec2 import Wav2Vec2Config
 
 import argparse
 
+
 def get_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--hf_model_id", default="facebook/wav2vec2-base", type=str, help="Model ID of HuggingFace wav2vec2 which needs to be converted into TensorFlow")
-    parser.add_argument("--with_lm_head", action="store_true", help="Whether to use `Wav2Vec2Model` or `Wav2Vec2ForCTC` from `wav2vec2/modeling.py`")
-    parser.add_argument("--verbose", default=False, type=bool, help="Whether to display specific layers conversion while running conversion script")
-    parser.add_argument("--saved_model_dir", default="saved-model/", type=str, help="Where to save the obtained `saved-model`")
-    parser.add_argument("--seqlen", default=246000, type=int, help="With what sequence length should model be exported")
+    parser.add_argument(
+        "--hf_model_id",
+        default="facebook/wav2vec2-base",
+        type=str,
+        help="Model ID of HuggingFace wav2vec2 which needs to be converted into TensorFlow",
+    )
+    parser.add_argument(
+        "--with_lm_head",
+        action="store_true",
+        help="Whether to use `Wav2Vec2Model` or `Wav2Vec2ForCTC` from `wav2vec2/modeling.py`",
+    )
+    parser.add_argument(
+        "--verbose",
+        default=False,
+        type=bool,
+        help="Whether to display specific layers conversion while running conversion script",
+    )
+    parser.add_argument(
+        "--saved_model_dir",
+        default="saved-model/",
+        type=str,
+        help="Where to save the obtained `saved-model`",
+    )
+    parser.add_argument(
+        "--seqlen",
+        default=246000,
+        type=int,
+        help="With what sequence length should model be exported",
+    )
     return parser
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     args = get_parser().parse_args()
 
     # spec_augmentation can't be supported with saved_model for now
     config = Wav2Vec2Config(apply_spec_augment=False)
-    model, _ = get_tf_pretrained_model(config, args.hf_model_id, verbose=args.verbose, with_lm_head=args.with_lm_head)
+    model, _ = get_tf_pretrained_model(
+        config, args.hf_model_id, verbose=args.verbose, with_lm_head=args.with_lm_head
+    )
 
     input_signature = [tf.TensorSpec((None, args.seqlen), tf.float32, name="speech")]
     model.__call__ = tf.function(model.__call__, input_signature=input_signature)

--- a/src/main.py
+++ b/src/main.py
@@ -89,19 +89,23 @@ class TrainingArgs:
         if DUMMY_DATA_PATH != "none":
             self.train_dir = self.val_dir = self.test_dir = None
             self.train_tfrecords = tf.io.gfile.glob(DUMMY_DATA_PATH)
-            self.test_tfrecords = self.val_tfrecords  = self.train_tfrecords
+            self.test_tfrecords = self.val_tfrecords = self.train_tfrecords
             assert self.from_tfrecords
         else:
             if self.from_tfrecords:
                 self.train_dir = self.val_dir = self.test_dir = None
 
-                train_tfrecords = [f"{record}*.tfrecord" for record in self.train_tfrecords]
+                train_tfrecords = [
+                    f"{record}*.tfrecord" for record in self.train_tfrecords
+                ]
                 self.train_tfrecords = tf.io.gfile.glob(train_tfrecords)
 
                 val_tfrecords = [f"{record}*.tfrecord" for record in self.val_tfrecords]
                 self.val_tfrecords = tf.io.gfile.glob(val_tfrecords)
 
-                test_tfrecords = [f"{record}*.tfrecord" for record in self.test_tfrecords]
+                test_tfrecords = [
+                    f"{record}*.tfrecord" for record in self.test_tfrecords
+                ]
                 self.test_tfrecords = tf.io.gfile.glob(test_tfrecords)
 
                 assert (

--- a/src/make_tfrecords.py
+++ b/src/make_tfrecords.py
@@ -32,9 +32,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         "CLI to convert .flac dataset into .tfrecords format"
     )
-    parser.add_argument(
-        "--data_dir", default="../data/LibriSpeech/dev-clean", type=str
-    )
+    parser.add_argument("--data_dir", default="../data/LibriSpeech/dev-clean", type=str)
     parser.add_argument("-d", "--tfrecord_dir", default="dev-clean", type=str)
     parser.add_argument("-n", "--num_shards", default=1, type=int)
 
@@ -49,7 +47,10 @@ if __name__ == "__main__":
     # this will help TFRecordDataset to read shards in parallel from several files
     # Docs suggest to keep each shard around 100 MB in size, so choose num_shards accordingly
     num_records_per_file = len(dataloader) // args.num_shards
-    file_names = [os.path.join(args.tfrecord_dir, f"{args.tfrecord_dir}-{i}.tfrecord") for i in range(args.num_shards)]
+    file_names = [
+        os.path.join(args.tfrecord_dir, f"{args.tfrecord_dir}-{i}.tfrecord")
+        for i in range(args.num_shards)
+    ]
     writers = [tf.io.TFRecordWriter(file_name) for file_name in file_names]
 
     # following loops runs in O(n) time (assuming n = num_samples & for every tfrecord prepartion_take = O(1))

--- a/src/make_tfrecords.py
+++ b/src/make_tfrecords.py
@@ -52,8 +52,6 @@ if __name__ == "__main__":
     file_names = [os.path.join(args.tfrecord_dir, f"{args.tfrecord_dir}-{i}.tfrecord") for i in range(args.num_shards)]
     writers = [tf.io.TFRecordWriter(file_name) for file_name in file_names]
 
-    dataset = dataset.take(num_records_per_file*args.num_shards)
-
     # following loops runs in O(n) time (assuming n = num_samples & for every tfrecord prepartion_take = O(1))
     i, speech_stats, label_stats = 0, [], []
     pbar = tqdm(dataset, total=len(dataloader), desc=f"Preparing {file_names[i]} ... ")

--- a/src/training_utils.py
+++ b/src/training_utils.py
@@ -52,30 +52,3 @@ def is_tpu_available():
 
 def is_gpu_available():
     return len(tf.config.list_physical_devices("GPU")) > 0
-
-
-class LocalTPUClusterResolver(tf.distribute.cluster_resolver.TPUClusterResolver):
-    """LocalTPUClusterResolver."""
-
-    def __init__(self):
-        self._tpu = ""
-        self.task_type = "worker"
-        self.task_id = 0
-
-    def master(self, task_type=None, task_id=None, rpc_layer=None):
-        return None
-
-    def cluster_spec(self):
-        return tf.train.ClusterSpec({})
-
-    def get_tpu_system_metadata(self):
-        return tf.tpu.experimental.TPUSystemMetadata(
-            num_cores=8,
-            num_hosts=1,
-            num_of_cores_per_host=8,
-            topology=None,
-            devices=tf.config.list_logical_devices(),
-        )
-
-    def num_accelerators(self, task_type=None, task_id=None, config_proto=None):
-        return {"TPU": 8}

--- a/src/wav2vec2/processor.py
+++ b/src/wav2vec2/processor.py
@@ -9,7 +9,7 @@ import tensorflow as tf
 
 class Wav2Vec2Processor:
     def __init__(
-        self, is_tokenizer, do_normalize=True, vocab_path="../data/vocab.json"
+        self, is_tokenizer, do_normalize=True, vocab_path="./vocab.json"
     ):
         # whether to use as `feature_extractor` or `tokenizer`
 

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -1,0 +1,65 @@
+import sys
+sys.path.extend(["src", "../src"])
+
+import unittest
+from functools import partial
+
+import numpy as np
+import tensorflow as tf
+
+from utils import try_download_file, if_path_exists
+from wav2vec2 import Wav2Vec2Processor
+from data_utils import (
+    LibriSpeechDataLoader,
+    LibriSpeechDataLoaderArgs,
+    TimitDataLoaderArgs,
+    TimitDataLoader,
+)
+
+TFRECORD_URL = "https://huggingface.co/datasets/vasudevgupta/gsoc-librispeech/resolve/main/dev-clean/dev-clean-0.tfrecord"
+LIBRISPEECH_DIR = "data/LibriSpeech/dev-clean"
+WAV_PATH = "data/sample.wav"
+FLAC_PATH = "data/sample2.flac"
+
+
+class DataLoaderTester(unittest.TestCase):
+    def setUp(self):
+        self.tokenizer = Wav2Vec2Processor(is_tokenizer=True)
+
+    def test_librispeech_tfrecords(self):
+        file_path = try_download_file(TFRECORD_URL)
+        data_args = LibriSpeechDataLoaderArgs(from_tfrecords=True, tfrecords=[file_path])
+        dataloader = LibriSpeechDataLoader(data_args)
+
+        for batch in dataloader(seed=None):
+            self.assertEqual((16, 400000), batch[0].shape)
+            target = "THE PATERNAL PARENT HAS A RIGHT TO HIS INFANTS NO DOUBT THAT WAS BOZLE'S LAW"
+            self.assertEqual(target, self.tokenizer.decode(batch[1][0].numpy().tolist()))
+            break
+
+    @partial(if_path_exists, path=LIBRISPEECH_DIR)
+    def test_librispeech_original(self):
+        data_args = LibriSpeechDataLoaderArgs(from_tfrecords=False, data_dir=LIBRISPEECH_DIR)
+        dataloader = LibriSpeechDataLoader(data_args)
+
+        for batch in dataloader(seed=None):
+            self.assertEqual((16, 400000), batch[0].shape)
+            break
+
+    @partial(if_path_exists, path=FLAC_PATH)
+    def test_read_flac(self):
+        dataloader = LibriSpeechDataLoader(LibriSpeechDataLoaderArgs())
+        audio = dataloader.read_sound(FLAC_PATH)
+        target = tf.constant([
+            6.1035156e-05, 1.8310547e-04, 5.4931641e-04, 3.6621094e-04, 3.3569336e-04, 5.1879883e-04, 7.6293945e-04, 8.5449219e-04
+        ])
+        self.assertTrue(np.allclose(audio[32:40].numpy(), target.numpy()))
+
+    @partial(if_path_exists, path=WAV_PATH)
+    def test_read_wav(self):
+        dataloader = TimitDataLoader(TimitDataLoaderArgs())
+        audio = dataloader.read_sound(WAV_PATH)
+        target = tf.constant([
+            0.01438822, 0.01776027, 0.01438822, 0.02113231, 0.01438822, 0.00764414, 0.00764414, -0.00921606
+        ])
+        self.assertTrue(np.allclose(audio[32:40].numpy(), target.numpy()))

--- a/tests/test_wav2vec2.py
+++ b/tests/test_wav2vec2.py
@@ -141,7 +141,10 @@ class Wav2Vec2Tester(unittest.TestCase):
         for hf_model_id in HF_MODEL_IDS:
             config = Wav2Vec2Config()
             tf_model, hf_model = get_tf_pretrained_model(
-                config, hf_model_id, verbose=False, with_lm_head=True,
+                config,
+                hf_model_id,
+                verbose=False,
+                with_lm_head=True,
             )
             batch, hf_batch, _, _ = self._get_batches()
             tf_logits = tf_model(batch).numpy()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,9 @@
 import importlib
 import unittest
 
+import os
+import subprocess
+
 
 def is_transformers_available():
     try:
@@ -24,4 +27,23 @@ def requires_lib(test_case, lib: list):
     conditions = [mapping[k] for k in lib]
     if not all(conditions):
         return unittest.skip(f"{lib} NOT AVAILABLE")(test_case)
+    return test_case
+
+
+def try_download_file(url: str):
+    file_name = os.path.abspath(os.path.split(url)[-1])
+    if os.path.isfile(file_name):
+        return file_name
+    try:
+        print(f"Downloading file from {url}", end=" ... ")
+        subprocess.run(["wget", url], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        print("done!")
+    except Exception as e:
+        raise ValueError(e)
+    return file_name
+
+
+def if_path_exists(test_case, path: str):
+    if not any([os.path.isfile(path), os.path.isdir(path)]):
+        return unittest.skip(f"{path} doesn't exist")(test_case)
     return test_case


### PR DESCRIPTION
### Major changes

* Time complexity of tfrecords sharding is reduced from `O(n^2)` to `O(n)`. `skip` method is very slow as it makes the `dataset` iterates over the samples again, so removed it.
* Added support for loading TIMIT dataset. Introduced `CommonDataLoader` for keeping common code for LibriSpeech & Timit dataloaders.

@sayakpaul @MorganR 